### PR TITLE
Privacy policy updates

### DIFF
--- a/app/src/main/java/org/mozilla/tiktokreporter/apppolicy/AppPolicyScreen.kt
+++ b/app/src/main/java/org/mozilla/tiktokreporter/apppolicy/AppPolicyScreen.kt
@@ -174,11 +174,13 @@ private fun AppPolicyScreenContent(
                         )
                         Spacer(modifier = Modifier.height(MozillaDimension.L))
                     }
-                    item {
-                        MarkdownText(
-                            markdown = state.subtitle, style = MozillaTypography.H5
-                        )
-                        Spacer(modifier = Modifier.height(MozillaDimension.M))
+                    if (state.subtitle.trim().isNotEmpty()) {
+                        item {
+                            MarkdownText(
+                                markdown = state.subtitle, style = MozillaTypography.H5
+                            )
+                            Spacer(modifier = Modifier.height(MozillaDimension.M))
+                        }
                     }
                     item {
                         MarkdownText(

--- a/app/src/main/java/org/mozilla/tiktokreporter/email/EmailScreen.kt
+++ b/app/src/main/java/org/mozilla/tiktokreporter/email/EmailScreen.kt
@@ -18,14 +18,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.jeziellago.compose.markdowntext.MarkdownText
 import org.mozilla.tiktokreporter.R
 import org.mozilla.tiktokreporter.TikTokReporterError
-import org.mozilla.tiktokreporter.common.FormFieldError
-import org.mozilla.tiktokreporter.common.FormFieldUiComponent
 import org.mozilla.tiktokreporter.common.formcomponents.formComponentsItems
 import org.mozilla.tiktokreporter.ui.components.LoadingScreen
 import org.mozilla.tiktokreporter.ui.components.MozillaScaffold
@@ -176,6 +176,9 @@ private fun EmailScreenContent(
                         formFields = formFields, onFormFieldValueChanged = fun(formFieldId, value) {
                             onFormFieldValueChanged(formFieldId, value, mode)
                         }
+                    )
+                    MarkdownText(
+                        markdown = stringResource(R.string.email_policy_markdown), style = MozillaTypography.Body2, linkColor = Color.Blue
                     )
                 }
             }

--- a/app/src/main/java/org/mozilla/tiktokreporter/email/EmailScreen.kt
+++ b/app/src/main/java/org/mozilla/tiktokreporter/email/EmailScreen.kt
@@ -63,6 +63,9 @@ fun EmailScreen(
                     if (mode == EmailScreenMode.ONBOARDING) onNextScreen()
                     else onNavigateBack()
                 }
+                EmailScreenViewModel.UiAction.EmailRemoved -> {
+                    Toast.makeText(context, R.string.email_removed, Toast.LENGTH_SHORT).show()
+                }
                 EmailScreenViewModel.UiAction.ShowDataDownloaded -> {
                     Toast.makeText(context, R.string.toast_download_my_data, Toast.LENGTH_SHORT).show()
                 }
@@ -111,6 +114,7 @@ fun EmailScreen(
                 onFormFieldValueChanged = viewModel::onFormFieldValueChanged,
                 onNavigateBack = onNavigateBack,
                 onSaveEmail = if (mode === EmailScreenMode.SETTINGS_DATA_HANDLING) viewModel::onSaveDataHandlingEmail else viewModel::onSaveEmail,
+                onRemoveEmail = viewModel::onRemoveEmail,
                 onNextScreen = onNextScreen,
                 mode = mode,
                 modifier = Modifier.fillMaxSize()
@@ -125,6 +129,7 @@ private fun EmailScreenContent(
     onFormFieldValueChanged: (formFieldId: String, value: Any, mode: EmailScreenMode) -> Unit,
     onNavigateBack: () -> Unit,
     onSaveEmail: () -> Unit,
+    onRemoveEmail: (mode: EmailScreenMode) -> Unit,
     onNextScreen: () -> Unit,
     mode: EmailScreenMode,
     modifier: Modifier = Modifier
@@ -192,6 +197,20 @@ private fun EmailScreenContent(
                     if (mode != EmailScreenMode.SETTINGS_UPDATES) {
                         PrimaryButton(
                             modifier = Modifier.fillMaxWidth(), text = stringResource(id = R.string.save), onClick = onSaveEmail
+                        )
+                    } else if (state.userEmail.isNotEmpty()) {
+                        MarkdownText(
+                            modifier = Modifier.fillMaxWidth().padding(PaddingValues(
+                                vertical = MozillaDimension.M
+                            )),
+                            markdown = stringResource(R.string.email_remove_description), style = MozillaTypography.Body2, linkColor = Color.Blue
+                        )
+                        SecondaryButton(
+                            modifier = Modifier.fillMaxWidth(),
+                            text = stringResource(R.string.email_remove),
+                            onClick = fun() {
+                                onRemoveEmail(mode)
+                            }
                         )
                     }
                 }, skipButton = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,9 @@
     <string name="sign_up_for_updates">Sign up for updates</string>
     <string name="email_for_data_download">Email address for data download</string>
     <string name="email_policy_markdown">By providing your email address, you agree to Mozilla\'s [Privacy Notice](https://www.mozilla.org/privacy/).</string>
+    <string name="email_remove_description">You can remove your email address or opt-out of any communications at any time.</string>
+    <string name="email_remove">Remove email</string>
+    <string name="email_removed">Email address removed, you will no longer receive communications.</string>
     <string name="settings">Settings</string>
     <string name="not_now">Not now</string>
     <string name="delete">Delete</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="back">Back</string>
     <string name="sign_up_for_updates">Sign up for updates</string>
     <string name="email_for_data_download">Email address for data download</string>
+    <string name="email_policy_markdown">By providing your email address, you agree to Mozilla\'s [Privacy Notice](https://www.mozilla.org/privacy/).</string>
     <string name="settings">Settings</string>
     <string name="not_now">Not now</string>
     <string name="delete">Delete</string>


### PR DESCRIPTION

<summary>

Show privacy policy link on email forms

<details>

![image](https://github.com/MozillaFoundation/tiktok-reporter-app-android/assets/191195/90151f41-a107-4238-8e8a-fbb183686ec4)

</details>
</summary>

<summary>

Test updated policy that's just links and hide app policy subtitle if empty string

<details>

![image](https://github.com/MozillaFoundation/tiktok-reporter-app-android/assets/191195/752c93e3-2562-48b8-abe6-235221ff0a14)

</details>
</summary>

<summary>

Add option to remove email from settings

<details>

![image](https://github.com/MozillaFoundation/tiktok-reporter-app-android/assets/191195/05cb3da3-fbd7-4a20-91ef-bbcd543f124a)
![image](https://github.com/MozillaFoundation/tiktok-reporter-app-android/assets/191195/2b0ebdf0-e5fb-4c4d-806a-e68bd890c3c3)

</details>
</summary>
